### PR TITLE
Update mongo.md 中jenssegers/mongodb的版本号

### DIFF
--- a/resource/doc/zh-cn/db/mongo.md
+++ b/resource/doc/zh-cn/db/mongo.md
@@ -9,7 +9,7 @@ webman默认使用 [jenssegers/mongodb](https://github.com/jenssegers/laravel-mo
 ## 安装
 
 ```php
-composer require -W webman/database jenssegers/mongodb ^3.8.0
+composer require -W webman/database jenssegers/mongodb ^4.8
 ```
 
 安装后需要restart重启(reload无效)


### PR DESCRIPTION
原 jenssegers/mongodb ^3.8.0 依赖  illuminate/support[v8.0.0, ..., v8.83.27]。需切换的4.8使用