### PR TITLE
补充缺失的函数

### DIFF
--- a/resource/doc/zh-cn/others/disable-function-check.md
+++ b/resource/doc/zh-cn/others/disable-function-check.md
@@ -32,6 +32,7 @@ pcntl_signal_dispatch
 pcntl_signal
 pcntl_alarm
 pcntl_fork
+pcntl_wait
 posix_getuid
 posix_getpwuid
 posix_kill


### PR DESCRIPTION
实际运行需要`pcntl_wait`函数, 但是文档里遗漏了, 所以补上